### PR TITLE
Add event_type to payload, update "Failure" -> "Failed"

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -15,10 +15,10 @@ def post_status(event, context):
     if severity == "DEBUG":
         state = "Success"
     payload = {
-	# NOTE: These webhooks originate from Dataflow, but we're using
-	# Prefectisms ("prefect_webhook", "flow_run_name") for backwards
-	# compatibility during the transition from Prefect -> Dataflow.
-	# These can be changed once all systems switch to Dataflow.
+        # NOTE: These webhooks originate from Dataflow, but we're using
+        # Prefectisms ("prefect_webhook", "flow_run_name") for backwards
+        # compatibility during the transition from Prefect -> Dataflow.
+        # These can be changed once all systems switch to Dataflow.
         "event_type": "prefect_webhook",
         "client_payload": {"flow_run_name": job_name, "state": state},
     }

--- a/src/main.py
+++ b/src/main.py
@@ -14,7 +14,10 @@ def post_status(event, context):
     state = "Failure"
     if severity == "DEBUG":
         state = "Success"
-    payload = {"client_payload": {"flow_run_name": job_name, "state": state}}
+    payload = {
+        "event_type": "prefect_webhook",
+        "client_payload": {"flow_run_name": job_name, "state": state},
+    }
     headers = {
         "Authorization": f"token {os.environ['PAT']}",
         "Accept": "application/vnd.github.v3+json",

--- a/src/main.py
+++ b/src/main.py
@@ -15,6 +15,10 @@ def post_status(event, context):
     if severity == "DEBUG":
         state = "Success"
     payload = {
+	# NOTE: These webhooks originate from Dataflow, but we're using
+	# Prefectisms ("prefect_webhook", "flow_run_name") for backwards
+	# compatibility during the transition from Prefect -> Dataflow.
+	# These can be changed once all systems switch to Dataflow.
         "event_type": "prefect_webhook",
         "client_payload": {"flow_run_name": job_name, "state": state},
     }

--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,7 @@ def post_status(event, context):
     job_name = message["resource"]["labels"]["job_name"]
     severity = message["severity"]
     print(job_name)
-    state = "Failure"
+    state = "Failed"
     if severity == "DEBUG":
         state = "Success"
     payload = {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,7 +27,7 @@ def test_post_status(requests):
     post_status(event, {})
     requests.post.assert_called_once_with(
         f"https://api.github.com/repos/{org}/{repo}/dispatches",
-        data=f'{{"client_payload": {{"flow_run_name": "{job_name}", "state": "Success"}}}}',
+        data=f'{{"event_type": "prefect_webhook", "client_payload": {{"flow_run_name": "{job_name}", "state": "Success"}}}}',
         headers={
             "Authorization": f"token {pat}",
             "Accept": "application/vnd.github.v3+json",


### PR DESCRIPTION
We were missing the `event_type` in the payload, which was causing a 422 error when the function was called. xref:

> https://github.com/pangeo-forge/registrar/blob/fd4244bccfb93a608f738c0fbcddbfca4d3ff602/registrar/automation_hooks.py#L13

This appears to resolve the issue.