### PR TITLE
Remove trailing $ from failure regex

### DIFF
--- a/terraform/log_sink.tf
+++ b/terraform/log_sink.tf
@@ -1,6 +1,6 @@
 resource "google_logging_project_sink" "logsink" {
   name                   = "logsink"
   destination            = "pubsub.googleapis.com/projects/${var.project}/topics/${resource.google_pubsub_topic.topic.name}"
-  filter                 = "resource.type = dataflow_step AND logName=(\"projects/${var.project}/logs/dataflow.googleapis.com%2Fjob-message\") AND ((severity=ERROR AND textPayload=~\"^Workflow failed.*$\") OR (severity=DEBUG AND textPayload=~\"^Executing success step success.*$\"))"
+  filter                 = "resource.type = dataflow_step AND logName=(\"projects/${var.project}/logs/dataflow.googleapis.com%2Fjob-message\") AND ((severity=ERROR AND textPayload=~\"^Workflow failed.*\") OR (severity=DEBUG AND textPayload=~\"^Executing success step success.*$\"))"
   unique_writer_identity = true
 }


### PR DESCRIPTION
As shown in https://github.com/pangeo-forge/staged-recipes/pull/138#issuecomment-1170382523, success webhooks work when deployed from `main`. However, I never got a failure webhook following [this test deployment](https://github.com/pangeo-forge/staged-recipes/pull/138#issuecomment-1170410207), despite the fact that the associated Dataflow job did fail

<img width="500" alt="Screen Shot 2022-06-29 at 1 45 57 PM" src="https://user-images.githubusercontent.com/62192187/176541439-f715aef2-4d9a-47b8-8870-a04d1ad80a27.png">

Digging around on the GCP Console, it appears that the pub/sub push from the log sink never occurred. Looking at the Logs Explorer, we do have an ERROR line starting with the string `Workflow failed.`

<img width="800" alt="Screen Shot 2022-06-29 at 1 47 55 PM" src="https://user-images.githubusercontent.com/62192187/176541811-eec4f3f9-a25e-45a6-9f77-f4536f8e0f83.png">
 
As anticipated by the filter in our log sink:

https://github.com/pangeo-forge/dataflow-status-monitoring/blob/5daa3b6eff8ec2090738825234341ecb83440bbb/terraform/log_sink.tf#L4

With the exact filter applied to these ERROR results, the `Workflow failed.` line is not captured

<img width="478" alt="Screen Shot 2022-06-29 at 1 51 05 PM" src="https://user-images.githubusercontent.com/62192187/176542411-8a0c760b-d8dc-4553-bb64-27a13224495b.png">

> This filter is copied exactly from the source blog post https://cloud.google.com/community/tutorials/dataflow-notification-slack but perhaps that post has gone slightly stale. 🤷 

Now, with the trialing `$` dropped from the filter, that log line is captured

<img width="719" alt="Screen Shot 2022-06-29 at 1 52 42 PM" src="https://user-images.githubusercontent.com/62192187/176542671-d6070269-928e-46db-b9f0-0929aaf22739.png">


