### PR TITLE
Use secrets for GitHub PAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ GCP Resources to report the status of completed Dataflow jobs to a repository di
   - Cloud Build API
   - Cloud Pub/Sub API
   - Cloud Logging API
+  - Secret Manager API
 
 
 ## Environment Settings

--- a/terraform/function.tf
+++ b/terraform/function.tf
@@ -31,9 +31,13 @@ resource "google_cloudfunctions_function" "function" {
     resource   = resource.google_pubsub_topic.topic.id
   }
   environment_variables = {
-    PAT      = "${var.pat}"
     REPO_ORG = "${var.repo_org}"
     REPO     = "${var.repo}"
+  }
+  secret_environment_variables = {
+    key     = "PAT"
+    secret  = "github_repository_dispatch_pat"
+    version = "latest"
   }
 }
 

--- a/terraform/function.tf
+++ b/terraform/function.tf
@@ -34,7 +34,7 @@ resource "google_cloudfunctions_function" "function" {
     REPO_ORG = "${var.repo_org}"
     REPO     = "${var.repo}"
   }
-  secret_environment_variables = {
+  secret_environment_variables {
     key     = "PAT"
     secret  = "github_repository_dispatch_pat"
     version = "latest"

--- a/terraform/function.tf
+++ b/terraform/function.tf
@@ -40,6 +40,3 @@ resource "google_cloudfunctions_function" "function" {
     version = "latest"
   }
 }
-
-
-

--- a/terraform/function.tf
+++ b/terraform/function.tf
@@ -37,6 +37,6 @@ resource "google_cloudfunctions_function" "function" {
   secret_environment_variables {
     key     = "PAT"
     secret  = "github_repository_dispatch_pat"
-    version = "latest"
+    version = 1
   }
 }

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -1,0 +1,14 @@
+resource "google_secret_manager_secret" "secret-basic" {
+  secret_id = "github_repository_dispatch_pat-latest"
+
+  replication {
+    automatic = true
+  }
+}
+
+
+resource "google_secret_manager_secret_version" "secret-version-basic" {
+  secret = google_secret_manager_secret.secret-basic.id
+
+  secret_data = "${var.pat}"
+}

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -10,9 +10,16 @@ resource "google_secret_manager_secret" "secret-basic" {
   }
 }
 
-
 resource "google_secret_manager_secret_version" "secret-version-basic" {
   secret = google_secret_manager_secret.secret-basic.id
 
   secret_data = var.pat
+}
+
+resource "google_secret_manager_secret_iam_binding" "binding" {
+  secret_id = google_secret_manager_secret.secret-basic.secret_id
+  role = "roles/secretmanager.secretAccessor"
+  members = [
+    "serviceAccount:${var.project}@appspot.gserviceaccount.com",
+  ]
 }

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -1,8 +1,12 @@
 resource "google_secret_manager_secret" "secret-basic" {
-  secret_id = "github_repository_dispatch_pat-latest"
+  secret_id = "github_repository_dispatch_pat"
 
   replication {
-    automatic = true
+    user_managed {
+      replicas {
+        location = var.region
+      }
+    }
   }
 }
 

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -10,5 +10,5 @@ resource "google_secret_manager_secret" "secret-basic" {
 resource "google_secret_manager_secret_version" "secret-version-basic" {
   secret = google_secret_manager_secret.secret-basic.id
 
-  secret_data = "${var.pat}"
+  secret_data = var.pat
 }

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -18,7 +18,7 @@ resource "google_secret_manager_secret_version" "secret-version-basic" {
 
 resource "google_secret_manager_secret_iam_binding" "binding" {
   secret_id = google_secret_manager_secret.secret-basic.secret_id
-  role = "roles/secretmanager.secretAccessor"
+  role      = "roles/secretmanager.secretAccessor"
   members = [
     "serviceAccount:${var.project}@appspot.gserviceaccount.com",
   ]


### PR DESCRIPTION
This PR makes the `PAT` environment variable a Secret, as described in

> https://cloud.google.com/functions/docs/configuring/secrets#making_a_secret_accessible_to_a_function

AFAICT, this is doable entirely in terraform

- https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudfunctions_function#secret_environment_variables
- ~~https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret~~ 
- https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version